### PR TITLE
ci: make npm audit blocking on high/critical

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-      - name: npm audit (informational)
-        run: npm audit --omit=dev || true
+      - name: npm audit (blocking on high/critical)
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## What

Make the `npm audit` step in `.github/workflows/security.yml` **blocking on high/critical** advisories instead of swallowed by `|| true`.

```diff
-      - name: npm audit (informational)
-        run: npm audit --omit=dev || true
+      - name: npm audit (blocking on high/critical)
+        run: npm audit --omit=dev --audit-level=high
```

## Why

The step previously always passed (`|| true`), so dependency advisories never failed CI. With `--audit-level=high` the `audit` job now fails the workflow when a **high or critical** advisory is present, while still tolerating moderate/low. `--omit=dev` is preserved (production deps only).

Refs e-xode/scripts#3 (app-repo hardening, finding #18).