### PR TITLE
chore(deps): bump form-data to 4.0.6 — fix npm audit CVE (1 high -> 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4878,16 +4878,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -5119,9 +5119,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"


### PR DESCRIPTION
Ferme la **seule alerte** du dépôt : `form-data` **high** (injection CRLF via noms de champs et de fichiers multipart non échappés), ouverte depuis le **2026-06-21**.

| Paquet | Version | Scope |
| --- | --- | --- |
| `form-data` | 4.0.5 → 4.0.6 | transitif — `axios` (runtime) + `jsdom` (tests) |

**Aucune PR Dependabot n'existait** pour cette alerte. Hypothèse : les 5 PR obsolètes du dépôt saturent la limite par défaut `open-pull-requests-limit: 5`.

`axios` autorisait déjà la version corrigée (`^4.0.5`) → **refresh de lockfile suffisant** : pas de bump d'axios, pas d'`overrides`, `package.json` inchangé. Diff : 8 lignes de lockfile.

### Vérifications

`npm audit` → **0 vulnérabilité** · `npm run lint` → clean · `npm run build` → OK · **157 tests / 50 fichiers → tous verts**.

Suivi : e-xode/scripts#9